### PR TITLE
Pbi 197214 generalize adapter names in examples bacnet

### DIFF
--- a/content/configuration/pi-adapter-for-bacnet-data-selection-configuration.md
+++ b/content/configuration/pi-adapter-for-bacnet-data-selection-configuration.md
@@ -49,7 +49,7 @@ You can use the device configuration to choose an appropriate **DataCollectionMo
 
 ## Configure BACnet data selection
 
-Complete the following steps to configure the BACnet data selection. Use the `POST` method in conjunction with the following REST endpoint to initialize the configuration: `api/v1/configuration/<ComponentId>/DataSelection`
+Complete the following steps to configure the BACnet data selection. Use the `PUT` method in conjunction with the following REST endpoint to initialize the configuration: `api/v1/configuration/<ComponentId>/DataSelection`
 
 1. Using a text editor, create an empty text file.
 
@@ -65,10 +65,10 @@ Complete the following steps to configure the BACnet data selection. Use the `PO
 
 1. Open command line session. Change directory to the location of `DataSelection.json`.
 
-1. Enter the following cURL command (which uses the `POST` method) to initialize data selection for your data source.
+1. Enter the following cURL command (which uses the `PUT` method) to initialize data selection for your data source.
 
     ```bash
-    curl -d "@DataSelection.json" -H "Content-Type: application/json" -X POST "http://localhost:5590/api/v1/configuration/BACnet1/DataSelection"
+    curl -d "@DataSelection.json" -H "Content-Type: application/json" -X PUT "http://localhost:5590/api/v1/configuration/BACnet1/DataSelection"
     ```
 
     **Notes:**

--- a/content/configuration/pi-adapter-for-bacnet-data-source-configuration.md
+++ b/content/configuration/pi-adapter-for-bacnet-data-source-configuration.md
@@ -10,7 +10,7 @@ To use the BACnet adapter, you must configure the data source to receive data.
 
 ## Configure BACnet data source
 
-Complete the following steps to configure the BACnet data source. Use the `POST` method in conjunction with the following endpoint to initialize the configuration: `api/v1/configuration/<ComponentId>/DataSource`.
+Complete the following steps to configure the BACnet data source. Use the `PUT` method in conjunction with the following endpoint to initialize the configuration: `api/v1/configuration/<ComponentId>/DataSource`.
 
 1. Using a text editor, create an empty text file.
 
@@ -26,10 +26,10 @@ Complete the following steps to configure the BACnet data source. Use the `POST`
 
 1. Open a command line session. Change directory to the location of `ConfigureDataSource.json`.
 
-1. Enter the following cURL command (which uses the `POST` method) to initialize the BACnet data source configuration.
+1. Enter the following cURL command (which uses the `PUT` method) to initialize the BACnet data source configuration.
 
     ```bash
-    curl -d "@ConfigureDataSource.json" -H "Content-Type: application/json" -X POST "http://localhost:5590/api/v1/configuration/BACnet1/DataSource"
+    curl -d "@ConfigureDataSource.json" -H "Content-Type: application/json" -X PUT "http://localhost:5590/api/v1/configuration/BACnet1/DataSource"
     ```
 
     **Notes:**

--- a/content/configuration/toc.yml
+++ b/content/configuration/toc.yml
@@ -24,3 +24,7 @@
   href: ../main/shared-content/configuration/buffering-configuration.md
 - name: Logging configuration
   href: ../main/shared-content/configuration/logging-configuration.md
+- name: Logging configuration
+  href: ../main/shared-content/configuration/logging-configuration.md
+- name: PI Adapter for BACnet configuration examples
+  href: configuration-examples.md

--- a/content/configuration/toc.yml
+++ b/content/configuration/toc.yml
@@ -24,7 +24,5 @@
   href: ../main/shared-content/configuration/buffering-configuration.md
 - name: Logging configuration
   href: ../main/shared-content/configuration/logging-configuration.md
-- name: Logging configuration
-  href: ../main/shared-content/configuration/logging-configuration.md
 - name: PI Adapter for BACnet configuration examples
   href: configuration-examples.md


### PR DESCRIPTION
Adding example config topic to TOC. Also updating `POST` method to `PUT` for consistency with other adapters.