### PR TITLE
Discovery update

### DIFF
--- a/content/configuration/pi-adapter-for-bacnet-data-source-configuration.md
+++ b/content/configuration/pi-adapter-for-bacnet-data-source-configuration.md
@@ -131,6 +131,12 @@ A successful discovery populates the device configuration and provides informati
 
 The adapter [log](xref:LoggingConfiguration) indicates when discovery is complete.
 
+Rather than using automatic device discovery, you can instead perform a manual discovery by sending a `POST` request to the `discoveries` endpoint with the following parameters configured: `id`,`autoSelect`, and `Query`. 
+
+* For more information about the URL for `POST` request to the `discoveries` endpoint url, see [REST URLs](xref:DiscoveryConfiguration#rest-urls) in [Discovery](xref:DiscoveryConfiguration).
+
+* For more information about the `id`, `autoSelect`, and `Query` parameters, see [Discovery parameters](xref:DiscoveryConfiguration#discovery-parameters) in [Discovery](xref:DiscoveryConfiguration). Syntax includes a query method and a comma-separated list of identifiers for objects to discover. 
+
 ### Example log
 
 ```log


### PR DESCRIPTION
Hey Vinay,

I started making the edits per your email from yesterday, but I question adding so much detail to this section. We already have a couple topics that explain how discovery work: [Discovery](https://osisoft-dev.zoominsoftware.io/bundle/pi-adapter-bacnet-1-dot-1-release-prep/page/main/shared-content/configuration/discovery.html) and [BACnet data source discovery](https://osisoft-dev.zoominsoftware.io/bundle/pi-adapter-bacnet-1-dot-1-release-prep/page/configuration/pi-adapter-for-bacnet-data-source-discovery.html). Moreover, I'd just like to understand why we need to add this section.  Can we just link to these topics rather that reproducing content? 