### PR TITLE
Doc QA (257454)

### DIFF
--- a/content/configuration/configuration.md
+++ b/content/configuration/configuration.md
@@ -10,7 +10,7 @@ The examples in the configuration topics use `curl`, a commonly available tool o
 
 For more information on PI Adapter configuration tools, see [Configuration tools](xref:ConfigurationTools).
 
-## Quick start
+## Quick Start
 
 This Quick Start guides you through setup of each configuration file available for PI Adapter for BACnet. As you complete each step, perform each required configuration to establish a data flow from a data source to one or more endpoints. Some configurations are optional.
 

--- a/content/configuration/data-selection-configuration/polled-data-stream-configuration.md
+++ b/content/configuration/data-selection-configuration/polled-data-stream-configuration.md
@@ -4,7 +4,9 @@ uid: BACnetPolledDataStreamConfiguration
 
 # Polled data stream
 
-Polled data collection is the default data collection mode for the adapter. Under this mode of data collection, devices configured for polling will be requested at scheduled intervals for all properties whose data selection items have a **DataCollectionMode** of `Poll`. To avoid overloading the network, requests are limited by the **MaxConcurrentNetworkRequests** property on the Data Selection configuration. However, COV (Change of Value) is generally preferred when supported by the configured device, as data values will only be sent when they change, instead of every time the scheduled interval elapses.
+Polled data collection is the default data collection mode for the adapter. Under this mode of data collection, devices configured for polling will be requested at scheduled intervals for all properties whose data selection items have a **DataCollectionMode** of `Poll`. 
+
+To avoid overloading the network, requests are limited by the **MaxConcurrentNetworkRequests** property on the Data Selection configuration. However, Change of Value (COV) is generally preferred when supported by the configured device, as data values will only be sent when they change, instead of every time the scheduled interval elapses.
 
 ## Usage
 

--- a/content/configuration/pi-adapter-for-bacnet-data-selection-configuration.md
+++ b/content/configuration/pi-adapter-for-bacnet-data-selection-configuration.md
@@ -66,7 +66,7 @@ Complete the following steps to configure the BACnet data selection. Use the `PU
 
 1. Open command line session. Change directory to the location of `DataSelection.json`.
 
-1. Enter the following cURL command (which uses the `PUT` method) to initialize data selection for your data source.
+1. Enter the following curl command (which uses the `PUT` method) to initialize data selection for your data source.
 
     ```bash
     curl -d "@DataSelection.json" -H "Content-Type: application/json" -X PUT "http://localhost:5590/api/v1/configuration/BACnet1/DataSelection"

--- a/content/configuration/pi-adapter-for-bacnet-system-components-configuration.md
+++ b/content/configuration/pi-adapter-for-bacnet-system-components-configuration.md
@@ -6,7 +6,7 @@ uid: PIAdapterforBACnetSystemComponentsConfiguration
 
 PI Adapter for BACnet uses JSON configuration files in a protected directory on Windows and Linux to store configuration that is read on startup. While the files are accessible to view, OSIsoft recommends that you use REST or the EdgeCmd utility for any changes you make to the files.
 
-As part of making adapters as secure as possible, any passwords or secrets that you configure are stored in encrypted form where cryptographic key material is stored separately in a secure location. If you edit the files directly, the adapter may not work as expected.
+As part of making adapters as secure as possible, any passwords or privileged information that you configure are stored in encrypted form where cryptographic key material is stored separately in a secure location. If you edit the files directly, the adapter may not work as expected.
 
 **Note:** You can edit any single component or facet of the system individually using REST, but you can also configure the system as a whole with a single REST call.
 

--- a/content/health/adapter-health-for-bacnet.md
+++ b/content/health/adapter-health-for-bacnet.md
@@ -13,7 +13,7 @@ Dynamic data is sent every minute to configured health endpoints.
 The following health data are available:
 
 - [Device status](xref:DeviceStatusForBACnet)
-- [Next Health Message Expected](xref:NextHealthMessageExpectedForBACnet)
+- [Next health message expected](xref:NextHealthMessageExpectedForBACnet)
 
 ## AF structure
 

--- a/content/health/next-health-message-expected-for-bacnet.md
+++ b/content/health/next-health-message-expected-for-bacnet.md
@@ -4,7 +4,7 @@ uid: NextHealthMessageExpectedForBACnet
 
 # Next health message expected
 
-This property is similar to a heartbeat. A new value for `NextHealthMessageExpected` is sent by an individual adapter data component on a periodic basis while it is functioning properly. This value is a timestamp that indicates when the next value should be received. When monitoring, if the next value is not received by the indicated time, this likely means that there is an issue. It could be an issue with the adapter, adapter component, network connection between the health endpoint and the adapter, and so on.
+This property is similar to a heartbeat. A new value for `NextHealthMessageExpected` is sent by an individual adapter data component on a periodic basis while it is functioning properly. This value is a timestamp that indicates when the next value should be received. When monitoring, if the next value is not received by the indicated time, this likely means that there is an issue. It could be, for example, an issue with the adapter, an adapter component or the network connection between the health endpoint and the adapter.
 
 | Property                          | Type                                 | Description                            |
 |-----------------------------------|--------------------------------------|----------------------------------------|

--- a/content/index.md
+++ b/content/index.md
@@ -4,7 +4,7 @@ uid: PIAdapterforBACnetOverview
 
 # Overview
 
-PI Adapter for BACnet (Building Automation and Control Networks) is a data-collection component that transfers time-series data from source devices to OMF endpoints in OSIsoft Cloud Services or PI Servers. BACnet is a communication protocol that is developed and maintained by ASHRAE. The adapter adheres to ANSI/ASHRAE Standard 135-2012 and communicates with any device using BACnet/IP and devices that conform to other BACnet protocols using a BACnet gateway or router.
+PI Adapter for Building Automation and Control Networks (BACnet) is a data-collection component that transfers time-series data from source devices to OMF endpoints in OSIsoft Cloud Services or PI Servers. BACnet is a communication protocol that is developed and maintained by ASHRAE. The adapter adheres to ANSI/ASHRAE Standard 135-2012 and communicates with any device using BACnet/IP and devices that conform to other BACnet protocols using a BACnet gateway or router.
 
 ![PI Adapter for BACnet architecture](images/pi-adapter-for-bacnet-architecture-diagram.png)
 
@@ -16,8 +16,8 @@ You can install the adapter with a download kit that you can obtain from the OSI
 
 Using REST API, you can configure all functions of the adapter. The configurations are stored in JSON files. For data ingress, you must define an adapter component in the system components configuration for each data source to which the adapter will connect. You configure each adapter component with the connection information for the data source and the data to collect. For data egress, you must specify destinations for the data, including security for the outgoing connection. Additional configurations are available to egress health and diagnostics data, add buffering configuration to protect against data loss, and record logging information for troubleshooting purposes.
 
-Once you have configured the adapter and it is sending data, you can use administration functions to manage the adapter or individual ingress components of the adapter. Health and diagnostics functions monitor the status of connected devices, adapter system functions, the number of active data streams, the rate of data ingress, the rate of errors, and the rate of data egress.
+After you have configured the adapter and it is sending data, you can use administration functions to manage the adapter or individual ingress components of the adapter. Health and diagnostics functions monitor the status of connected devices, adapter system functions, the number of active data streams, the rate of data ingress, the rate of errors, and the rate of data egress.
 
 ## EdgeCmd utility
 
-OSIsoft also provides the EdgeCmd utility, a proprietary command line tool to configure and administer an adapter on both Linux and Windows operating systems. EdgeCmd utility is installed separately from the adapter.
+OSIsoft provides the EdgeCmd utility, a proprietary command line tool to configure and administer an adapter on both Linux and Windows operating systems. EdgeCmd utility is installed separately from the adapter.

--- a/content/installation/install-the-adapter.md
+++ b/content/installation/install-the-adapter.md
@@ -10,7 +10,7 @@ You can install adapters on either a Windows or Linux operating system. Before i
 
 Complete the following steps to install a PI adapter on a Windows computer:
 
-1. Download the Windows .msi file from the [OSIsoft Customer portal (https://customers.osisoft.com/s/products)](https://customers.osisoft.com/s/products).
+1. Download the Windows .msi file from the [OSIsoft Customer portal](https://customers.osisoft.com/s/products).
 
     **Note:** Customer login credentials are required to access the portal.
 
@@ -34,7 +34,7 @@ Complete the following steps to install a PI adapter on a Linux computer:
 
 **Note:** Before you begin installation, confirm that Linux socket receive buffers are configured for optimum performance. For more information, see [Linux installation note](xref:ReleaseNotes#linux-installation-note).
 
-1. Download the appropriate Linux distribution file from the [OSIsoft Customer portal (https://customers.osisoft.com/s/products)](https://customers.osisoft.com/s/products).
+1. Download the appropriate Linux distribution file from the [OSIsoft Customer portal](https://customers.osisoft.com/s/products).
 
     **Note:** Customer login credentials are required to access the portal.
 

--- a/content/pi-adapter-for-bacnet-overview/pi-adapter-for-bacnet-principles-of-operation.md
+++ b/content/pi-adapter-for-bacnet-overview/pi-adapter-for-bacnet-principles-of-operation.md
@@ -18,7 +18,7 @@ For more information, see [PI Adapter for BACnet data source configuration](xref
 
 ## Data collection
 
-The BACnet adapter collects time-series data from selected objects on BACnet devices. The adapter supports both polling and COV (Change of Value, unsolicited subscription) data collection modes, as defined by the BACnet specification.
+The BACnet adapter collects time-series data from selected objects on BACnet devices. The adapter supports both polling and Change of Value (COV, unsolicited subscription) data collection modes, as defined by the BACnet specification.
 
 ### Object types and data types
 
@@ -60,7 +60,7 @@ Metadata specific to the BACnet adapter:
 - **SourceId**: SourceId is constructed using the following pattern: {DeviceId}.{ObjectType}{ObjectId}.{PropertyIdentifier}
 - **LocalName**: The BACnet ObjectName as provided by the BACnet object
 
-The metadata level is set in [General configuration](xref:GeneralConfiguration). For the BAcnet adapter, the following metadata is sent for the individual level:
+The metadata level is set in [General configuration](xref:GeneralConfiguration). For the BACnet adapter, the following metadata is sent for the individual level:
 
 - `None`: No metadata
 - `Low`: AdapterType (_ComponentType_) and DataSource (_ComponentId_)

--- a/content/release-notes/release-notes.md
+++ b/content/release-notes/release-notes.md
@@ -71,9 +71,9 @@ Because the PI System often serves as a barrier protecting control system networ
 
 The practice of publicly disclosing internally discovered vulnerabilities is consistent with the Common Industrial Control System Vulnerability Disclosure Framework developed by the Industrial Control Systems Joint Working Group (ICSJWG). Despite the increased risk posed by greater transparency, OSIsoft is sharing this information to help you make an informed decision about when to upgrade to ensure your PI System has the best available protection.
 
-For more information, refer to [OSIsoft's Ethical Disclosure Policy (https://www.osisoft.com/ethical-disclosure-policy)](https://www.osisoft.com/ethical-disclosure-policy).
+For more information, refer to [OSIsoft's Ethical Disclosure Policy](https://www.osisoft.com/ethical-disclosure-policy).
 
-To report a security vulnerability, refer to [OSIsoft's Report a Security Vulnerability (https://www.osisoft.com/report-a-security-vulnerability)](https://www.osisoft.com/report-a-security-vulnerability).
+To report a security vulnerability, refer to [OSIsoft's Report a Security Vulnerability](https://www.osisoft.com/report-a-security-vulnerability).
 
 ### Vulnerability scoring
 

--- a/content/troubleshooting/troubleshoot-pi-adapter-for-bacnet.md
+++ b/content/troubleshooting/troubleshoot-pi-adapter-for-bacnet.md
@@ -8,7 +8,7 @@ If the adapter is not working as expected, you can troubleshoot by viewing messa
 
 ## Check configurations
 
-Incorrect configurations can interrupt data flow and cause errors in values and ranges. Perform the following steps confirm correct configuration for your adapter.
+Incorrect configurations can interrupt data flow and cause errors in values and ranges. Perform the following steps to confirm the correct configuration for your adapter.
 
 1. Navigate to [data source configuration](xref:PIAdapterforBACnetDataSourceConfiguration) and verify that the value entered for each parameter is correct.
 
@@ -25,11 +25,11 @@ Perform the following steps to verify active connections to the data source and 
 
 1. Based on your egress endpoints, verify that data values are updating.
 
-    * For PI Server, send a request to the PI Web API to verify that PI point values are updating. Use Postman or a Web browser to send the request. For more information, see [PI Web API Reference](https://techsupport.osisoft.com/Documentation/PI-Web-API/help/controllers/point.html).
+    * For PI Server, send a request to the PI Web API to verify that PI point values are updating. Use Postman or a web browser to send the request. For more information, see [PI Web API Reference](https://techsupport.osisoft.com/Documentation/PI-Web-API/help/controllers/point.html).
 
         Alternatively, use any PI Client software to read point values from the PI Data Archive directly.
 
-    * For OCS, view the OCS portal to verify that data streams are updating. For more information, see [Getting started with trend data](https://ocs-docs.osisoft.com/Content_Portal/Quickstarts/Getting-Started-Trend.html).
+    * For OCS, view the OCS portal to verify that data streams are updating. For more information, see [OSIsoft Cloud Services](https://ocs-docs.osisoft.com/Content_Portal/Quickstarts/Getting-Started-Trend.html).
 
         Alternatively, you can use Postman to send an API request to verify data streams. For more information, see [API calls for reading data](https://ocs-docs.osisoft.com/Content_Portal/Documentation/SequentialDataStore/Reading_Data_API.html).
 


### PR DESCRIPTION
Afternoon, Mark....

I've completed my QA review of the BACnet guide. Just a bunch of minor edits here and there for you to review. But there are a couple of additional things that I found that I wanted to mention to you:

- Is it cURL or curl when referencing the tool? I've seen it both ways in the document. 

- In the _pi-adapter-for-bacnet-data-source-configuration_ markdown file, there is a footnote in the **Include Properties** data source parameter but it doesn't have a hyperlink to the notes section below the table. Should that have one? I tried to add one but wasn't successful. 

- Two links in the **Check Connectivity** section of the _Troubleshooting_ MD file are being redirected to the OSI Cloud Services page. I did not change the links themselves - wasn't sure what was going on there. 

![image](https://user-images.githubusercontent.com/93216960/146841655-83aa827e-fb28-46e5-91f3-bf9923a37e00.png)

Please let me know if you'd like to set up any time to discuss. 

Thanks!

Karl