### PR TITLE
Rebrand OSIsoft msg format (379178) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # PI-Adapter-BACnet-Docs
-PI Adapter for BACnet is a data-collection component that transfers time-series data from source devices to OMF (OSIsoft Message Format) endpoints in OSIsoft Cloud Services or PI Servers.
+PI Adapter for BACnet is a data-collection component that transfers time-series data from source devices to Open Message Format (OMF) endpoints in OSIsoft Cloud Services or PI Servers.
 
 This repository contains the documentation for PI Adapter for BACnet. You can access a readable version of this documentation [here.](https://docs.osisoft.com/bundle/pi-adapter-bacnet/)
 
@@ -13,7 +13,7 @@ git subtree pull --prefix content/main https://github.com/osisoft/PI-Adapter mai
 
 ## License
 
-<a href="https://www.osisoft.com/copyright/">&copy; 2019 - 2021 OSIsoft, LLC. All rights reserved.</a>
+<a href="https://www.osisoft.com/copyright/">&copy; 2019 - 2023 OSIsoft, LLC. All rights reserved.</a>
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at:
 

--- a/classification.xml
+++ b/classification.xml
@@ -8,7 +8,7 @@
  xmlns:html="http://www.w3.org/TR/REC-html40">
  <DocumentProperties xmlns="urn:schemas-microsoft-com:office:office">
   <Author>Timothy Martin</Author>
-  <LastAuthor>Tina Ullmann</LastAuthor>
+  <LastAuthor>Karl Nyce</LastAuthor>
   <Revision>1</Revision>
   <Created>2021-03-29T20:56:44Z</Created>
   <LastSaved>2021-04-12T13:53:59Z</LastSaved>
@@ -981,16 +981,16 @@
     <Cell ss:Index="2" ss:StyleID="s89"><Data ss:Type="String">PI-OPC-DA-Server_2018-Patch-1</Data></Cell>
    </Row>
    <Row ss:AutoFitHeight="0" ss:Height="14.4375">
-    <Cell ss:Index="2" ss:StyleID="s65"><Data ss:Type="String">OSIsoft-Message-Format</Data></Cell>
+    <Cell ss:Index="2" ss:StyleID="s65"><Data ss:Type="String">Open-Message-Format</Data></Cell>
    </Row>
    <Row ss:AutoFitHeight="0" ss:Height="14.4375">
-    <Cell ss:Index="2" ss:StyleID="s89"><Data ss:Type="String">OSIsoft-Message-Format-1.2</Data></Cell>
+    <Cell ss:Index="2" ss:StyleID="s89"><Data ss:Type="String">Open-Message-Format-1.2</Data></Cell>
    </Row>
    <Row ss:AutoFitHeight="0" ss:Height="14.4375">
-    <Cell ss:Index="2" ss:StyleID="s90"><Data ss:Type="String">OSIsoft-Message-Format-1.1</Data></Cell>
+    <Cell ss:Index="2" ss:StyleID="s90"><Data ss:Type="String">Open-Message-Format-1.1</Data></Cell>
    </Row>
    <Row ss:AutoFitHeight="0" ss:Height="14.4375">
-    <Cell ss:Index="2" ss:StyleID="s90"><Data ss:Type="String">OSIsoft-Message-Format-1.0</Data></Cell>
+    <Cell ss:Index="2" ss:StyleID="s90"><Data ss:Type="String">Open-Message-Format-1.0</Data></Cell>
    </Row>
    <Row ss:AutoFitHeight="0" ss:Height="14.4375">
     <Cell ss:Index="2" ss:StyleID="s65"><Data ss:Type="String">PI-Web-API</Data></Cell>

--- a/classification.xml
+++ b/classification.xml
@@ -410,9 +410,9 @@
    <Row ss:AutoFitHeight="0">
     <Cell ss:StyleID="s75"><Data ss:Type="String">Developer</Data></Cell>
     <Cell ss:StyleID="s74"><Data ss:Type="String">developer</Data></Cell>
-    <Cell><Data ss:Type="String">OSIsoft Message Format (OMF)</Data></Cell>
-    <Cell ss:StyleID="s74"><Data ss:Type="String">OSIsoft-Message-Format</Data></Cell>
-    <Cell><Data ss:Type="String">OSIsoft Message Format (OMF)</Data></Cell>
+    <Cell><Data ss:Type="String">Open Message Format (OMF)</Data></Cell>
+    <Cell ss:StyleID="s74"><Data ss:Type="String">Open-Message-Format</Data></Cell>
+    <Cell><Data ss:Type="String">Open Message Format (OMF)</Data></Cell>
     <Cell ss:Index="7" ss:StyleID="s76"><Data ss:Type="String">Yes</Data></Cell>
    </Row>
    <Row ss:AutoFitHeight="0">

--- a/content/main/shared-content/configuration/egress-endpoints/prepare-egress-destinations.md
+++ b/content/main/shared-content/configuration/egress-endpoints/prepare-egress-destinations.md
@@ -4,7 +4,7 @@ uid: PrepareEgressDestinations
 
 # Prepare egress destinations
 
-OCS and PI Server destinations may require additional configuration to receive OMF messages.
+OCS and PI Server destinations may require additional configuration to receive Open Message Format (OMF) messages.
 
 ## OCS
 
@@ -24,7 +24,7 @@ To prepare OCS to receive OMF messages from the adapter, create an OMF connectio
 
 To prepare a PI Server to receive OMF messages from the adapter, a PI Web API OMF endpoint must be available. Complete the following steps:
 
-1. Install PI Web API and enable the **OSIsoft Message Format (OMF) Services** feature.
+1. Install PI Web API and enable the **Open Message Format (OMF) Services** feature.
     
     - During configuration, choose an AF database and PI Data Archive where metadata and data will be stored.
 


### PR DESCRIPTION
Rebrand all instances of OSIsoft Message Format to Open Message Format. 